### PR TITLE
feat: Analyze 'using' statement and add test cases

### DIFF
--- a/tests/test_module_a.sss
+++ b/tests/test_module_a.sss
@@ -1,0 +1,20 @@
+// Module for testing 'using' keyword
+
+#export {
+    exported_proc,
+    EXPORTED_CONST
+}
+
+EXPORTED_CONST :: 42;
+internal_var :: 100; // Not exported
+
+exported_proc :: proc(val : n32) -> n32 {
+    // For printing, we assume a global 'print_n32' procedure might exist,
+    // or this will just be for checking resolution.
+    // print_n32(val + EXPORTED_CONST + internal_var); 
+    erg val + EXPORTED_CONST;
+}
+
+non_exported_proc :: proc() -> n32 {
+    erg internal_var;
+}

--- a/tests/test_using_module.sss
+++ b/tests/test_using_module.sss
@@ -1,0 +1,49 @@
+// Test file for 'using' with a namespaced module
+
+// Assume 'print_n32' and 'print_string' are available globally for output,
+// or we will verify symbol resolution via compilation success/failure.
+// If not, results of calls can be assigned to variables that might be inspected by a test harness if possible.
+
+#import ModA = (*) aus "tests/test_module_a.sss"; // Import relative to where compiler runs
+
+main_test_proc :: proc() {
+    res_before_using : n32;
+    res_after_using : n32;
+    res_direct_const_after_using : n32;
+    
+    // 1. Access with prefix before 'using'
+    // print_string("Calling with prefix ModA.exported_proc(10):");
+    res_before_using = ModA.exported_proc(10); // Should be 10 + 42 = 52
+    // print_n32(res_before_using); 
+    // print_string("Accessing with prefix ModA.EXPORTED_CONST:");
+    // print_n32(ModA.EXPORTED_CONST);
+
+    mit ModA; // 'using ModA;'
+
+    // 2. Access directly after 'using'
+    // print_string("Calling directly exported_proc(20) after using:");
+    res_after_using = exported_proc(20); // Should be 20 + 42 = 62
+    // print_n32(res_after_using);
+    // print_string("Accessing directly EXPORTED_CONST after using:");
+    res_direct_const_after_using = EXPORTED_CONST; // Should be 42
+    // print_n32(res_direct_const_after_using);
+
+    // 3. Attempt to access non-exported symbol (should fail compilation if resolver prevents it,
+    //    or result in an error if accessed at runtime)
+    // print_string("Attempting to access ModA.internal_var (should fail):");
+    // test_non_exported_var = internal_var; // This should cause a compile error
+    // print_string("Attempting to call ModA.non_exported_proc (should fail):");
+    // test_non_exported_proc_res = non_exported_proc(); // This should cause a compile error
+
+    // For test harness purposes, if we can't print, assign to make sure they resolve:
+    val1 : n32 = res_before_using;       // Expected 52
+    val2 : n32 = res_after_using;       // Expected 62
+    val3 : n32 = res_direct_const_after_using; // Expected 42
+}
+
+// 4. Access with prefix after the scope of 'using' (if main_test_proc was not the whole file scope)
+//    This is implicitly tested by ModA.exported_proc above if it's in a different scope.
+//    If main_test_proc is global, then 'using' applies to its local scope.
+
+// Call the test procedure if possible (e.g. if this file is run directly)
+// main_test_proc();


### PR DESCRIPTION
This commit investigates the behavior of the 'using' statement in SSS, particularly its interaction with imported modules (via namespaces), enum types, and struct types.

Key findings from static analysis of the resolver:
- 'using <NamespaceIdentifier>;' correctly brings exported symbols from the namespace (created via '#import X = (*) from "file";') into your local scope.
- 'using <EnumType>;' correctly brings enum members into your local scope.
- Conflict resolution for symbols introduced by 'using' appears to be handled correctly by the existing 'scope_push' logic.
- 'using <StructType>;' would currently bring struct field names into your local scope as new, unassociated symbols. This behavior is potentially confusing if you expect it to provide direct access to instance fields (it does not). This area may warrant further design review or compiler warnings when a build environment is available.

I created new test files under 'tests/':
- tests/test_module_a.sss: A sample module with exported and non-exported symbols.
- tests/test_using_module.sss: Exercises 'using' with a namespace imported from test_module_a.sss. Includes commented-out code to test access to non-exported symbols (expected to fail compilation) and will serve as a basis for conflict testing.

No runtime-verified code changes were made to the resolver due to environmental constraints preventing the SSS compiler from being built. The analysis and test files form the primary outcome.